### PR TITLE
Preserve trailing spaces in poked files

### DIFF
--- a/src/document.js
+++ b/src/document.js
@@ -2,6 +2,7 @@
 
 var fs = require('fs'),
     Args = require('./args'),
+    TRAILING_SPACES_REGEX = /\s*$/,
     xmldom = require('xmldom'),
     xmlParser = new xmldom.DOMParser(),
     xmlSerializer = new xmldom.XMLSerializer(),
@@ -106,6 +107,7 @@ function openXmlFile(path, encoding) {
 
 function loadXml(source) {
     var document = xmlParser.parseFromString(source);
+    var trailingSpaces = TRAILING_SPACES_REGEX.exec(source)[0];
     var basePath, namespaces, errorOnNoMatches;
 
     var query = function(path, errorOnNoMatches, addIfMissing, alwaysAdd) {
@@ -179,7 +181,8 @@ function loadXml(source) {
         },
 
         toString: function() {
-            return xmlSerializer.serializeToString(document);
+            var s = xmlSerializer.serializeToString(document);
+            return s.replace(TRAILING_SPACES_REGEX, trailingSpaces)
         }
     };
     return dsl;


### PR DESCRIPTION
Currently, using `xmlpoke` to modify a XML document discards all spaces that were present at the end of the source.
This is a nuisance when one wants all files to have a trailing newline character.

This change preserves all trailing spaces in a modified document.

IMHO `xmlpoke` is the right place for this feature, since it's about preserving spaces *outside* of the actual XML document. So one could argue that this is outside of the responsibility of `xmldom`.

The implementation is chosen such that, even if `xmldom` should implement this feature someday, we will not add more trailing spaces than in the original document.